### PR TITLE
add build workflow

### DIFF
--- a/.github/actions/dep_install_and_lint/action.yaml
+++ b/.github/actions/dep_install_and_lint/action.yaml
@@ -1,0 +1,28 @@
+name: "Install Dependencies and Run Linter"
+description: "Installs dependencies and runs the Rust linter."
+
+inputs:
+  working-directory:
+    description: 'The working directory for the linter'
+    required: true
+    default: '.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Dependencies
+      run: |
+        sudo apt update && sudo apt install libdw-dev
+        cargo install cargo-sort
+        rustup update
+        rustup toolchain install nightly
+        rustup component add clippy --toolchain nightly
+        rustup component add rustfmt --toolchain nightly
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Run Linter
+      run: |
+        scripts/rust_lint.sh --check
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}

--- a/.github/scripts/build_and_push_images.sh
+++ b/.github/scripts/build_and_push_images.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is to build and push aptos indexer processors v2 images.
+# You need to execute this from the repository root as working directory
+# E.g. scripts/build-and-push-images.sh
+# E.g. scripts/build-and-push-images.sh python
+# Note that this uses kaniko (https://github.com/GoogleContainerTools/kaniko) instead of vanilla docker to build the images, which has good remote caching support
+
+set -ex
+
+TARGET_REGISTRY="us-docker.pkg.dev/aptos-registry/docker/indexer-client-examples/nft-aggregator"
+# take GIT_SHA from environment variable if set, otherwise use git rev-parse HEAD
+GIT_SHA="${GIT_SHA:-$(git rev-parse HEAD)}"
+EXAMPLE_TO_BUILD_ARG="${1:-all}"
+
+if [ "$CI" == "true" ]; then
+    CREDENTIAL_MOUNT="$HOME/.docker/:/kaniko/.docker/:ro"
+else
+    # locally we mount gcloud config credentials
+    CREDENTIAL_MOUNT="$HOME/.config/gcloud:/root/.config/gcloud:ro"
+fi
+
+# Normalize GIT_BRANCH if it's set
+if [ -n "${GIT_BRANCH}" ]; then
+    export NORMALIZED_GIT_BRANCH=$(printf "${GIT_BRANCH}" | sed -e 's/[^a-zA-Z0-9]/-/g')
+fi
+
+# Set DESTINATIONS based on GIT_SHA since that is always set
+DESTINATIONS="--destination ${TARGET_REGISTRY}:${GIT_SHA}"
+
+# If GIT_BRANCH is set and not empty, add it as an additional tag
+if [ -n "${NORMALIZED_GIT_BRANCH}" ]; then
+    DESTINATIONS="${DESTINATIONS} --destination ${TARGET_REGISTRY}:${NORMALIZED_GIT_BRANCH}"
+    DESTINATIONS="${DESTINATIONS} --destination ${TARGET_REGISTRY}:${NORMALIZED_GIT_BRANCH}_${GIT_SHA}"
+fi
+
+# build and push the image
+docker run \
+    --rm \
+    -v $CREDENTIAL_MOUNT \
+    -v $(pwd):/workspace \
+    gcr.io/kaniko-project/executor:latest \
+    --dockerfile /workspace/Dockerfile \
+    $DESTINATIONS \
+    --context dir:///workspace/ \
+    --cache=true

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "scripts",
+    "description": "Scripts for aptos-indexer-processors",
+    "version": "1.0.0",
+    "packageManager": "pnpm@8.6.2",
+    "main": "index.js",
+    "scripts": {
+        "release-processor-images": "./release-processor-images.mjs"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "devDependencies": {
+      "typescript": "=4.8.4",
+      "zx": "^7.1.1"
+    },
+    "peerDependencies": {}
+  }

--- a/.github/scripts/release-processor-images.mjs
+++ b/.github/scripts/release-processor-images.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env -S node
+
+
+// This script releases indexer processor images to docker hub https://github.com/aptos-labs/aptos-indexer-processors.
+// It does so by copying the images from aptos GCP artifact registry to docker hub.
+
+// Usually it's run in CI, but you can also run it locally in emergency situations, assuming you have the right credentials.
+// Before you run this locally, check one more time whether you can trigger a CI build instead which is usually easier and safer.
+// You can do so via the Github UI or CLI:
+// E.g: gh workflow run copy-processor-images-to-dockerhub.yaml
+//
+// If that doesn't work for you, you can run this script locally:
+//
+// Prerequisites when running locally:
+// 1. Tools:
+//  - docker
+//  - gcloud
+//  - node (node.js)
+//  - crane - https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation
+//  - pnpm - https://pnpm.io/installation
+// 2. docker login - with authorization to push to the `aptoslabs` org
+// 3. gcloud auth configure-docker us-west1-docker.pkg.dev
+// 4. gcloud auth login --update-adc
+//
+// Once you have all prerequisites fulfilled, you can run this script via (note the GH context and vars):
+// GIT_SHA=${{ github.sha }} GCP_DOCKER_ARTIFACT_REPO="${{ vars.GCP_DOCKER_ARTIFACT_REPO }}" ./docker/release-processor-images.mjs --language=rust --wait-for-image-seconds=1800
+
+
+import { dirname } from "node:path";
+import { chdir } from "node:process";
+import { promisify } from "node:util";
+const sleep = promisify(setTimeout);
+
+// Change workdir to the root of the repo.
+chdir(dirname(process.argv[1]) + "/..");
+
+await import("zx/globals");
+
+const REQUIRED_ARGS = ["LANGUAGE", "GIT_SHA", "GCP_DOCKER_ARTIFACT_REPO"];
+const OPTIONAL_ARGS = ["VERSION_TAG", "WAIT_FOR_IMAGE_SECONDS"];
+
+const parsedArgs = {};
+
+for (const arg of REQUIRED_ARGS) {
+  const argValue = argv[arg.toLowerCase().replaceAll("_", "-")] ?? process.env[arg];
+  if (!argValue) {
+    console.error(chalk.red(`ERROR: Missing required argument or environment variable: ${arg}`));
+    process.exit(1);
+  }
+  parsedArgs[arg] = argValue;
+}
+
+for (const arg of OPTIONAL_ARGS) {
+  const argValue = argv[arg.toLowerCase().replaceAll("_", "-")] ?? process.env[arg];
+  parsedArgs[arg] = argValue;
+}
+
+// Default 10 seconds.
+parsedArgs.WAIT_FOR_IMAGE_SECONDS = parseInt(parsedArgs.WAIT_FOR_IMAGE_SECONDS ?? 10, 10);
+
+let crane;
+
+if (process.env.CI === "true") {
+  console.log("installing crane automatically in CI");
+  await $`curl -sL https://github.com/google/go-containerregistry/releases/download/v0.15.1/go-containerregistry_Linux_x86_64.tar.gz > crane.tar.gz`;
+  const sha = (await $`shasum -a 256 ./crane.tar.gz | awk '{ print $1 }'`).toString().trim();
+  if (sha !== "d4710014a3bd135eb1d4a9142f509cfd61d2be242e5f5785788e404448a4f3f2") {
+    console.error(chalk.red(`ERROR: sha256 mismatch for crane.tar.gz got: ${sha}`));
+    process.exit(1);
+  }
+  await $`tar -xf crane.tar.gz`;
+  crane = "./crane";
+} else {
+  if ((await $`command -v crane`.exitCode) !== 0) {
+    console.log(
+      chalk.red(
+        "ERROR: could not find crane binary in PATH - follow https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation to install",
+      ),
+    );
+    process.exit(1);
+  }
+  crane = "crane";
+}
+
+function getImage(language) {
+    const sourceImage = `indexer-client-examples/${language}`;
+    const targetImage = `indexer-processor-${language}`;
+    return {sourceImage, targetImage};
+}
+
+const GCP_DOCKER_ARTIFACT_REPO = parsedArgs.GCP_DOCKER_ARTIFACT_REPO;
+const DOCKERHUB = "docker.io/aptoslabs";
+
+const {sourceImage, targetImage} = getImage(parsedArgs.LANGUAGE);
+console.info(chalk.yellow(`INFO: Target image: ${targetImage}`));
+
+const imageSource = `${GCP_DOCKER_ARTIFACT_REPO}/${sourceImage}:${parsedArgs.GIT_SHA}`;
+const imageGitShaTarget = `${DOCKERHUB}/${targetImage}:${parsedArgs.GIT_SHA}`;
+
+console.info(chalk.green(`INFO: Waiting for ${imageSource} to become available in the source repo`));
+await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);
+
+console.info(chalk.green(`INFO: Copying ${imageSource} to ${imageGitShaTarget}`));
+await $`${crane} copy ${imageSource} ${imageGitShaTarget}`;
+
+console.info(chalk.green(`INFO: Tagging image as latest`));
+await $`${crane} tag ${imageGitShaTarget} latest`;
+
+if(parsedArgs.VERSION_TAG !== null) {
+    console.info(chalk.green(`INFO: Tagging image as ${parsedArgs.VERSION_TAG} and ${parsedArgs.VERSION_TAG}_${parsedArgs.GIT_SHA}`));
+    await $`${crane} tag ${imageGitShaTarget} ${parsedArgs.VERSION_TAG}`; // just the version tag
+    await $`${crane} tag ${imageGitShaTarget} ${parsedArgs.VERSION_TAG}_${parsedArgs.GIT_SHA}`; // version tag with git sha
+}
+
+async function waitForImageToBecomeAvailable(imageToWaitFor, waitForImageSeconds) {
+  const WAIT_TIME_IN_BETWEEN_ATTEMPTS = 10000; // 10 seconds in ms
+  const startTimeMs = Date.now();
+  function timeElapsedSeconds() {
+    return (Date.now() - startTimeMs) / 1000;
+  }
+  while (timeElapsedSeconds() < waitForImageSeconds) {
+    try {
+      await $`${crane} manifest ${imageToWaitFor}`;
+      console.info(chalk.green(`INFO: image ${imageToWaitFor} is available`));
+      return;
+    } catch (e) {
+      if (e.exitCode === 1 && e.stderr.includes("MANIFEST_UNKNOWN")) {
+        console.log(
+          chalk.yellow(
+            // prettier-ignore
+            `WARN: Image ${imageToWaitFor} not available yet - waiting ${WAIT_TIME_IN_BETWEEN_ATTEMPTS / 1000} seconds to try again. Time elapsed: ${timeElapsedSeconds().toFixed(0,)} seconds. Max wait time: ${waitForImageSeconds} seconds`,
+          ),
+        );
+        await sleep(WAIT_TIME_IN_BETWEEN_ATTEMPTS);
+      } else {
+        console.error(chalk.red(e.stderr ?? e));
+        process.exit(1);
+      }
+    }
+  }
+  console.error(
+    chalk.red(
+      `ERROR: timed out after ${waitForImageSeconds} seconds waiting for image to become available: ${imageToWaitFor}`,
+    ),
+  );
+  process.exit(1);
+}

--- a/.github/workflow/build-images.yaml
+++ b/.github/workflow/build-images.yaml
@@ -1,0 +1,50 @@
+name: "Build Docker Images"
+on:
+  # Allow us to run this specific workflow without a PR
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# cancel redundant builds
+concurrency:
+  # for push and workflow_dispatch events we use `github.sha` in the concurrency group and don't really cancel each other out/limit concurrency
+  # for pull_request events newer jobs cancel earlier jobs to save on CI etc.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+      
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/docker-setup
+        with:
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Build and push images
+        run: ./scripts/build_and_push_images.sh
+        env:
+          GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflow/copy-processor-images-to-dockerhub.yaml
+++ b/.github/workflow/copy-processor-images-to-dockerhub.yaml
@@ -1,0 +1,56 @@
+name: Copy Processor Images to DockerHub on Release
+on:
+  push:
+    tags:
+      - aptos-indexer-processors-v*
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation
+
+jobs:
+  copy-processor-images:
+    # Run on a machine with more local storage for large docker images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
+        with:
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: .node-version
+
+      - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin https://github.com/pnpm/action-setup/releases/tag/v4.0.0
+        with:
+          run_install: false
+          package_json_file: ./github/scripts/package.json
+
+      - run: pnpm install --frozen-lockfile
+        working-directory: ./github/scripts
+
+      - name: Install Dependencies and Run Linter
+        uses: ./.github/actions/dep_install_and_lint
+        with:
+          working-directory: .
+
+      - name: Run Integration Tests for Specific Crate
+        run: cargo test --manifest-path integration-tests/Cargo.toml
+        working-directory: .
+
+      - name: Release Images
+        env:
+          FORCE_COLOR: 3 # Force color output as per https://github.com/google/zx#using-github-actions
+          GIT_SHA: ${{ github.sha }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
+        run: pnpm release-processor-images --language=${{ inputs.processor_language }} --version-tag=${{ github.ref_name }} --wait-for-image-seconds=3600
+        working-directory: ./github/scripts


### PR DESCRIPTION
### TL;DR
Added GitHub Actions workflows for building and managing Docker images for the indexer processors.

### What changed?
- Added a build script (`build_and_push_images.sh`) that uses Kaniko to build and push Docker images to Google Artifact Registry
- Created GitHub Actions workflow for building Docker images on PR, push to main, and manual triggers
- Added workflow for copying processor images to DockerHub when new releases are tagged