### PR TITLE
[DO NOT MERGE] backfill activities

### DIFF
--- a/src/steps/db_writing_step.rs
+++ b/src/steps/db_writing_step.rs
@@ -195,7 +195,21 @@ pub fn insert_nft_marketplace_activities(
     diesel::insert_into(schema::nft_marketplace_activities::table)
         .values(items_to_insert)
         .on_conflict((txn_version, index, marketplace))
-        .do_nothing()
+        .do_update()
+        .set((
+            token_data_id.eq(excluded(token_data_id)),
+            collection_id.eq(excluded(collection_id)),
+            seller.eq(excluded(seller)),
+            price.eq(excluded(price)),
+            listing_id.eq(excluded(listing_id)),
+            token_amount.eq(excluded(token_amount)),
+            token_name.eq(excluded(token_name)),
+            creator_address.eq(excluded(creator_address)),
+            collection_name.eq(excluded(collection_name)),
+            raw_event_type.eq(excluded(raw_event_type)),
+            standard_event_type.eq(excluded(standard_event_type)),
+            expiration_time.eq(excluded(expiration_time)),
+        ))
 }
 
 pub fn insert_current_nft_marketplace_listings(


### PR DESCRIPTION
### TL;DR

Update NFT marketplace activities conflict resolution strategy from `do_nothing` to `do_update`.

### What changed?

Modified the conflict resolution strategy in the `insert_nft_marketplace_activities` function. Instead of ignoring conflicts with `do_nothing()`, the function now updates existing records with the new values using `do_update()`. This ensures that all fields are properly updated when a conflict occurs on the composite key of `(txn_version, index, marketplace)`.

### How to test?

1. Create a test case that attempts to insert NFT marketplace activities with the same `txn_version`, `index`, and `marketplace` but different values for other fields
2. Verify that the existing record is updated with the new values rather than being ignored
3. Check that all fields (token_data_id, collection_id, seller, price, etc.) are properly updated in the database

### Why make this change?

This change ensures data consistency by updating existing records when conflicts occur rather than silently ignoring them. This is particularly important for NFT marketplace activities where data might be reprocessed or updated with more accurate information over time.